### PR TITLE
Add roles dir and install roles in bootstrap

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -21,7 +21,9 @@ if (!(Test-Path "C:\stig-pipe")) {
     git clone (Get-Location).Path "C:\stig-pipe"
 }
 
+# Change to repo directory and install Ansible roles
 Set-Location "C:\stig-pipe"
+ansible-galaxy install -r ansible\requirements.yml --roles-path roles\
 
 # Execute remediation pipeline
 Write-Host "Getting SCAP content..."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,7 +25,9 @@ if [[ ! -d /opt/stig-pipe ]]; then
     sudo chown -R "$(whoami):$(whoami)" /opt/stig-pipe
 fi
 
+# Change to repo directory and install Ansible roles
 cd /opt/stig-pipe
+ansible-galaxy install -r ansible/requirements.yml --roles-path roles/
 
 # Get SCAP content
 echo "Getting SCAP content..."


### PR DESCRIPTION
## Summary
- add an empty roles directory
- install Ansible roles during both bootstrap scripts

## Testing
- `git ls-tree -r HEAD --name-only | grep roles`

------
https://chatgpt.com/codex/tasks/task_e_683c73ea65cc832eae6bdcdc8afd8f5e