### PR TITLE
Add root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Ignore Ansible roles downloaded at runtime
+roles/
+
+# Ignore downloaded SCAP content
+scap_content/
+
+# Ignore generated scan reports
+reports/
+
+# General build artifacts and logs
+*.log
+*.tmp
+*~
+.DS_Store
+


### PR DESCRIPTION
## Summary
- add `.gitignore` to keep build artifacts out of version control

## Testing
- `sudo bash bootstrap.sh --dry-run` *(fails: Unable to locate package ansible)*
- `./scripts/get_scap_content.sh --os rhel-8`
- `./scripts/scan.sh --baseline` *(fails: No SCAP content found)*
- `ansible-playbook ansible/remediate.yml --check` *(fails: command not found)*
- `./scripts/verify.sh` *(fails: No SCAP content found)*

------
https://chatgpt.com/codex/tasks/task_e_683c73f486b0832e86db03895aab2281