### PR TITLE
Add CI bootstrap dry run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run bootstrap dry run
+        run: sudo bash bootstrap.sh --dry-run
+      - name: Upload reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: reports
+          path: reports/


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run the bootstrap script in dry‑run mode

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683c740af4a4832ea9d5225bbad3783a