### PR TITLE
Update CI workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- add explicit permissions to `build` job in CI workflow

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683c7676ed44832ea1398d27d40aa9c2