### PR TITLE
Add DryRun switch to PowerShell bootstrap

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,41 +1,61 @@
 #Requires -RunAsAdministrator
 
+[CmdletBinding()]
+param(
+    [switch]$DryRun
+)
+
+function Run {
+    param(
+        [string]$Command
+    )
+    if ($DryRun) {
+        Write-Host $Command
+    } else {
+        Invoke-Expression $Command
+    }
+}
+
+if ($DryRun) {
+    Write-Host "Dry run mode - commands will be printed only" -ForegroundColor Yellow
+}
+
 # Enable WinRM
-Set-Item WSMan:\localhost\Service\Auth\Basic -Value $true
-Enable-PSRemoting -Force
+Run 'Set-Item WSMan:\localhost\Service\Auth\Basic -Value $true'
+Run 'Enable-PSRemoting -Force'
 
 # Install Chocolatey if not present
 if (!(Get-Command choco -ErrorAction SilentlyContinue)) {
     Write-Host "Installing Chocolatey..."
-    Set-ExecutionPolicy Bypass -Scope Process -Force
-    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-    iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+    Run 'Set-ExecutionPolicy Bypass -Scope Process -Force'
+    Run "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072"
+    Run 'iex ((New-Object System.Net.WebClient).DownloadString("https://community.chocolatey.org/install.ps1"))'
 }
 
 # Install required packages
-choco install git ansible openscap -y
+Run 'choco install git ansible openscap -y'
 
 # Clone repo to C:\stig-pipe if not present
 if (!(Test-Path "C:\stig-pipe")) {
     Write-Host "Cloning repository to C:\stig-pipe"
-    git clone https://github.com/NotINeverMe/stig-auto.git "C:\stig-pipe"
+    Run 'git clone https://github.com/NotINeverMe/stig-auto.git "C:\stig-pipe"'
 }
 
 # Change to repo directory and install Ansible roles
-Set-Location "C:\stig-pipe"
-ansible-galaxy install -r ansible\requirements.yml --roles-path roles\
+Run 'Set-Location "C:\stig-pipe"'
+Run 'ansible-galaxy install -r ansible\requirements.yml --roles-path roles\'
 
 # Execute remediation pipeline
 Write-Host "Getting SCAP content..."
-& scripts\get_scap_content.ps1
+Run '& scripts\get_scap_content.ps1'
 
 Write-Host "Running baseline scan..."
-& scripts\scan.ps1 -Baseline
+Run '& scripts\scan.ps1 -Baseline'
 
 Write-Host "Running Ansible remediation..."
-ansible-playbook ansible\remediate.yml -t CAT_I,CAT_II
+Run 'ansible-playbook ansible\remediate.yml -t CAT_I,CAT_II'
 
 Write-Host "Verifying remediation..."
-& scripts\verify.ps1
+Run '& scripts\verify.ps1'
 
 Write-Host "Remediation complete" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- add `-DryRun` switch to `bootstrap.ps1`
- implement `Run` helper to print commands when in dry run mode

## Testing
- `pwsh -NoLogo -Command "./bootstrap.ps1 -DryRun"` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c76a00828832e953d7ece97db70da