### PR TITLE
Filter SCAP asset by OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ iex (irm https://raw.githubusercontent.com/NotINeverMe/stig-auto/main/bootstrap.
 Clone the repo, install roles, fetch SCAP content, then run:
 
 ```bash
+./scripts/get_scap_content.sh [--os rhel8]
 ./scripts/scan.sh --baseline
 ansible-playbook ansible/remediate.yml -t CAT_I,CAT_II
 ./scripts/verify.sh
 ```
+Use `--os` (Linux) or `-OS` (Windows) to override automatic OS detection when downloading SCAP content.
 
 ## Updates
 


### PR DESCRIPTION
## Summary
- filter ComplianceAsCode release assets by operating system
- document optional OS override flag

## Testing
- `bash -n scripts/get_scap_content.sh`

------
https://chatgpt.com/codex/tasks/task_e_683c89cd4848832eb7704efa0b87d2fb