### PR TITLE
Handle oscap exit code 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Reports are saved in the `reports/` directory:
 - `report-after-*.html` - Post-remediation verification
 Reports appear under `reports/` with before and after HTML summaries.
 
+## Exit Codes
+
+OpenSCAP returns exit code `2` when one or more rules fail. The `scan.sh` and
+`scan.ps1` scripts capture this status and continue running, only exiting if the
+code is something other than `0` or `2`.
+
 ## License
 
 See [LICENSE](LICENSE) for the proprietary license terms. Usage requires explicit permission from the repository owner.

--- a/scripts/scan.ps1
+++ b/scripts/scan.ps1
@@ -33,13 +33,18 @@ try {
     # Run OpenSCAP evaluation
     $ResultsFile = "reports\results-$Mode-$Timestamp.arf"
     $ReportFile = "reports\report-$Mode-$Timestamp.html"
-    
+
     & oscap.exe xccdf eval `
         --profile stig `
         --results $ResultsFile `
         --report $ReportFile `
         $ScapFile.FullName
-    
+
+    $rc = $LASTEXITCODE
+    if ($rc -ne 0 -and $rc -ne 2) {
+        throw "OpenSCAP failed with exit code $rc"
+    }
+
     Write-Host "Scan complete. Results saved to:"
     Write-Host "  ARF: $ResultsFile"
     Write-Host "  HTML: $ReportFile"

--- a/scripts/scan.sh
+++ b/scripts/scan.sh
@@ -45,12 +45,19 @@ fi
 echo "Using SCAP content: $SCAP_FILE"
 echo "Running $MODE scan..."
 
-# Run OpenSCAP evaluation
+
+# Run OpenSCAP evaluation and capture the exit code. OpenSCAP returns
+# exit code 2 when rules fail but the scan itself succeeded, so the
+# script should continue in that case.
+rc=0
 oscap xccdf eval \
     --profile stig \
     --results "reports/results-${MODE}-${TIMESTAMP}.arf" \
     --report "reports/report-${MODE}-${TIMESTAMP}.html" \
-    "$SCAP_FILE"
+    "$SCAP_FILE" || rc=$?
+if [[ $rc -ne 0 && $rc -ne 2 ]]; then
+    exit $rc
+fi
 
 echo "Scan complete. Results saved to:"
 echo "  ARF: reports/results-${MODE}-${TIMESTAMP}.arf"


### PR DESCRIPTION
## Summary
- allow scan scripts to continue when oscap exits with code 2
- mention the oscap exit code in the README

## Testing
- `bash -n scripts/scan.sh`

------
https://chatgpt.com/codex/tasks/task_e_683c89f2442c832e8cae5878ab3026f5