### PR TITLE
Add offline prep instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ git pull
 ansible-galaxy install -r ansible/requirements.yml --roles-path roles/ --force
 ```
 
+## Offline Preparation
+
+You can stage content on a machine with internet access and then copy it to an
+offline target.
+
+```bash
+# Fetch Ansible roles
+ansible-galaxy install -r ansible/requirements.yml --roles-path roles/
+
+# Download SCAP content for the desired OS
+./scripts/get_scap_content.sh --os rhel-8
+```
+
+Transfer the `roles/` and `scap_content/` directories to the offline system
+before running the pipeline. The `--os` flag tells `get_scap_content.sh` exactly
+which content to download.
+
 ## Supported Systems
 
 - RHEL 8


### PR DESCRIPTION
## Summary
- document how to pre-download Ansible roles and SCAP content
- mention using `--os` flag when running `get_scap_content.sh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683c8a288c8c832e8d44b15c80ce5987