### PR TITLE
Expand quick start roles instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ curl -fsSL https://raw.githubusercontent.com/NotINeverMe/stig-auto/main/bootstra
 iex (irm https://raw.githubusercontent.com/NotINeverMe/stig-auto/main/bootstrap.ps1)
 ```
 
+After cloning the repository or running the bootstrap script, install the Ansible roles:
+
+```bash
+ansible-galaxy install -r ansible/requirements.yml --roles-path roles/
+```
+
+This pulls the STIG roles from the Git repositories specified in `ansible/requirements.yml`.
+
 ## Overview
 
 1. Download SCAP content


### PR DESCRIPTION
## Summary
- call `ansible-galaxy install` in quick start and explain role sources

## Testing
- `sudo bash bootstrap.sh --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_683c8a293c78832e8cf19e4d91e51506