### PR TITLE
Add report validation for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run bootstrap script in dry-run mode
         run: sudo bash bootstrap.sh --dry-run
+      - name: Validate reports directory
+        run: |
+          if [ ! -d "reports" ] || [ -z "$(ls -A reports)" ]; then
+            echo "The reports directory is missing or empty"
+            exit 1
+          fi
       - name: Upload reports
         uses: actions/upload-artifact@v3
         with:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,6 +25,13 @@ run_cmd() {
     fi
 }
 
+# Create a placeholder reports directory when running in dry-run mode so that
+# CI pipelines expecting artifacts have something to upload.
+if $DRY_RUN; then
+    mkdir -p reports
+    : > reports/dry-run.txt
+fi
+
 # Detect package manager and install dependencies
 if command -v apt &> /dev/null; then
     echo "Detected apt package manager"


### PR DESCRIPTION
## Summary
- create a placeholder reports directory during `bootstrap.sh --dry-run`
- validate the reports directory before uploading artifacts in CI

## Testing
- `bash -n bootstrap.sh`
- `bash -n scripts/*.sh`


------
https://chatgpt.com/codex/tasks/task_e_683c8b4733ac832e8d98712e68568de9