### PR TITLE
Ensure reports directory is created during dry-run

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,6 +25,13 @@ run_cmd() {
     fi
 }
 
+# If running in dry-run mode, create a placeholder reports directory so
+# subsequent scripts have an expected location to write to.
+if $DRY_RUN; then
+    mkdir -p reports
+    echo "Placeholder for dry run" > reports/dry-run.txt
+fi
+
 # Determine STIG profile based on local OS
 detect_stig_profile() {
     if [[ -f /etc/os-release ]]; then


### PR DESCRIPTION
## Summary
- enhance `bootstrap.sh` dry run mode

## Testing
- `shellcheck bootstrap.sh scripts/*.sh` *(fails: command not found)*
- `ansible-playbook ansible/remediate.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c8c81bf1c832e9c8fa98fc1e26300