### PR TITLE
Fix ShellCheck path handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run ShellCheck
         run: |
           docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck-alpine:v0.9.0 \
-            shellcheck $(git ls-files '*.sh')
+            shellcheck -x $(git ls-files '*.sh')
       - name: Install Ansible
         run: |
           sudo apt-get update


### PR DESCRIPTION
## Summary
- update ShellCheck invocation in CI to follow sourced files

## Testing
- `sudo bash bootstrap.sh --dry-run`
- `docker run ... shellcheck -x` *(fails: `docker: command not found`)*
- `ansible-playbook ansible/remediate.yml --syntax-check` *(fails: `ansible-playbook: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c9d668dd4832eba048c88dc28936c