### PR TITLE
Fix role path and install Galaxy roles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ansible
+      - name: Install Ansible roles
+        run: |
+          ansible-galaxy install -r ansible/requirements.yml --roles-path roles/
       - name: Ansible syntax check
         run: ansible-playbook ansible/remediate.yml --syntax-check
       - name: Run bootstrap script in dry-run mode

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ./roles


### PR DESCRIPTION
## Summary
- create an `ansible.cfg` to point Ansible at `./roles`
- install Galaxy roles during the CI run

## Testing
- `apt-get update` *(fails: no network)*

------
https://chatgpt.com/codex/tasks/task_e_683c9e47d474832e822815c46f314971