### PR TITLE
Fix invalid RHEL8 STIG role version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ansible
+      - name: Validate rhel8-stig tag
+        run: |
+          TAG="$(awk '/rhel8-stig/{getline; getline; print $2}' ansible/requirements.yml | tr -d '"')"
+          git ls-remote --exit-code --tags https://github.com/ansible-lockdown/RHEL8-STIG.git "refs/tags/$TAG"
       - name: Install Ansible roles
         run: |
           ansible-galaxy install -r ansible/requirements.yml --roles-path roles/

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -2,7 +2,7 @@
 roles:
   - name: rhel8-stig
     src: git+https://github.com/ansible-lockdown/RHEL8-STIG.git
-    version: v3.4.0
+    version: "4.0.0"
   - name: ubuntu22-stig
     src: git+https://github.com/ansible-lockdown/UBUNTU22-STIG.git
     version: v1.2.0


### PR DESCRIPTION
## Summary
- update the RHEL8 STIG role version
- validate the tag during CI

## Testing
- `sudo bash bootstrap.sh --dry-run`
- `ansible-galaxy install -r ansible/requirements.yml --roles-path roles/` *(fails: `ansible-galaxy: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_683c9fcc0b48832e8c38668a25391bdc