### PR TITLE
Fix invalid Ubuntu STIG tag and add tag validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ansible
-      - name: Validate rhel8-stig tag
+      - name: Validate role versions exist
         run: |
-          TAG="$(awk '/rhel8-stig/{getline; getline; print $2}' ansible/requirements.yml | tr -d '"')"
-          git ls-remote --exit-code --tags https://github.com/ansible-lockdown/RHEL8-STIG.git "refs/tags/$TAG"
+          awk '/^ *- name:/{role=$3} /^ *version:/{ver=$2; gsub(/["\047]/, "", ver);
+               cmd=sprintf("git ls-remote --exit-code --tags https://github.com/ansible-lockdown/%s.git refs/tags/%s", toupper(role), ver);
+               system(cmd)}' ansible/requirements.yml
       - name: Install Ansible roles
         run: |
           ansible-galaxy install -r ansible/requirements.yml --roles-path roles/

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -5,7 +5,7 @@ roles:
     version: "4.0.0"
   - name: ubuntu22-stig
     src: git+https://github.com/ansible-lockdown/UBUNTU22-STIG.git
-    version: v1.2.0
+    version: "2.2.0"
   - name: windows2022-stig
     src: git+https://github.com/ansible-lockdown/WINDOWS2022-STIG.git
     version: v1.4.0


### PR DESCRIPTION
## Summary
- update ubuntu22-stig Ansible role to a valid release
- validate all STIG role tags before installing
- fix quoting in the awk command for tag validation

## Testing
- `bash bootstrap.sh --dry-run`
- `./scripts/get_scap_content.sh --help`
- `./scripts/scan.sh --help`

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683ca2324aac832eb34a521dde9d0a6a