### PR TITLE
Fix role version

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -5,7 +5,7 @@ roles:
     version: "4.0.0"
   - name: ubuntu22-stig
     src: git+https://github.com/ansible-lockdown/UBUNTU22-STIG.git
-    version: "2.2.0"
+    version: "2.1.0"
   - name: windows2022-stig
     src: git+https://github.com/ansible-lockdown/WINDOWS2022-STIG.git
     version: v1.4.0


### PR DESCRIPTION
## Summary
- point to a valid version for ubuntu22-stig in requirements

## Testing
- `git ls-remote https://github.com/ansible-lockdown/UBUNTU22-STIG.git | head` *(fails: no network)*

------
https://chatgpt.com/codex/tasks/task_e_683ca9ed5108832eb4d8aa8b2b0df903