### PR TITLE
Fix role version validation command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,19 @@ jobs:
           sudo apt-get install -y ansible
       - name: Validate role versions exist
         run: |
-          awk '/^ *- name:/{role=$3} /^ *version:/{ver=$2; gsub(/["\'\']/, "", ver);
-               cmd=sprintf("git ls-remote --exit-code --tags https://github.com/ansible-lockdown/%s.git refs/tags/%s", toupper(role) ".git", ver);
-               system(cmd)}' ansible/requirements.yml
+          awk '
+            /^ *- name:/ { role = $3 }
+            /^ *version:/ {
+              gsub(/["'"]/, "", ver)
+              repo_name_part = toupper(role)
+              cmd = sprintf("git ls-remote --exit-code --tags https://github.com/ansible-lockdown/%s.git refs/tags/%s", repo_name_part, ver)
+              print "Validating role: " role ", version: " ver " (Repo: https://github.com/ansible-lockdown/" repo_name_part ".git)"
+              if (system(cmd) != 0) {
+                print "Error: Validation failed for role '\''" role "'\'', version '\''" ver "'\'' using command: " cmd
+                exit 1
+              }
+            }
+          ' ansible/requirements.yml
       - name: Install Ansible roles
         run: |
           ansible-galaxy install -r ansible/requirements.yml --roles-path roles/


### PR DESCRIPTION
## Summary
- fix the CI workflow step that validates role versions

## Testing
- `docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck-alpine:v0.9.0 shellcheck -x $(git ls-files '*.sh')` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cab7127fc832eb53f6196aba7a76e