### PR TITLE
Fix CI awk syntax error in role version validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,20 @@ jobs:
           sudo apt-get install -y ansible
       - name: Validate role versions exist
         run: |
-          awk '/^ *- name:/{role=$3} /^ *version:/{ver=$2; gsub(/["\'\']/, "", ver);
-               cmd=sprintf("git ls-remote --exit-code --tags https://github.com/ansible-lockdown/%s.git refs/tags/%s", toupper(role) ".git", ver);
-               system(cmd)}' ansible/requirements.yml
+          awk '
+            /^ *- name:/ { role = $3 }
+            /^ *version:/ { 
+              ver = $2
+              gsub(/["'\'']/, "", ver)
+              repo = toupper(role)
+              cmd = sprintf("git ls-remote --exit-code --tags https://github.com/ansible-lockdown/%s.git refs/tags/%s", repo, ver)
+              print "Validating " role " version " ver
+              if (system(cmd) != 0) {
+                print "Error: Version " ver " not found for " role
+                exit 1
+              }
+            }
+          ' ansible/requirements.yml
       - name: Install Ansible roles
         run: |
           ansible-galaxy install -r ansible/requirements.yml --roles-path roles/


### PR DESCRIPTION
## Summary
- Fixed syntax error in GitHub Actions CI workflow that was causing builds to fail
- The awk command for validating Ansible role versions had improper quote escaping and formatting issues

## Changes
- Properly escaped quotes in `gsub` regex pattern (`gsub(/["'\'']/, "", ver)`)
- Restructured awk script with proper multi-line YAML formatting for better readability
- Added error handling and validation output messages for debugging
- Removed incorrect `.git` concatenation in `sprintf` function

## Test plan
- [x] Verify CI workflow runs without syntax errors
- [x] Confirm role version validation logic works correctly
- [x] Test that malformed versions are properly caught and reported

🤖 Generated with [Claude Code](https://claude.ai/code)