### PR TITLE
Fix ubuntu22-stig version to correct 1.0.0 release

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -5,7 +5,7 @@ roles:
     version: "4.0.0"
   - name: ubuntu22-stig
     src: git+https://github.com/ansible-lockdown/UBUNTU22-STIG.git
-    version: "2.1.0"
+    version: "1.0.0"
   - name: windows2022-stig
     src: git+https://github.com/ansible-lockdown/WINDOWS2022-STIG.git
     version: v1.4.0


### PR DESCRIPTION
## Summary
- Fixed ubuntu22-stig version from non-existent `2.1.0` to actual `1.0.0` release
- The ansible-lockdown/UBUNTU22-STIG repository only has version 1.0.0, which implements DISA Ubuntu 22 STIG V2R2

## Changes
- Updated `ansible/requirements.yml` to use correct version `1.0.0` for ubuntu22-stig role

## Validation
The repository at https://github.com/ansible-lockdown/UBUNTU22-STIG has only one release:
- Version: 1.0.0 
- Implements: UBUNTU 22 DISA STIG Version 2, Release 2 (Oct 24, 2024)

This resolves the CI failure where the role version validation was failing.

## Test plan
- [x] Verify version 1.0.0 exists in the ubuntu22-stig repository
- [x] Test that ansible-galaxy can install the role with this version
- [x] Confirm CI validation step passes

🤖 Generated with [Claude Code](https://claude.ai/code)