### PR TITLE
Fix Windows 2022 STIG repository name and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,11 @@ jobs:
             /^ *version:/ { 
               ver = $2
               gsub(/["'\'']/, "", ver)
-              repo = toupper(role)
+              # Map role names to correct repository names
+              if (role == "rhel8-stig") repo = "RHEL8-STIG"
+              else if (role == "ubuntu22-stig") repo = "UBUNTU22-STIG"  
+              else if (role == "windows2022-stig") repo = "Windows-2022-STIG"
+              else repo = toupper(role)
               cmd = sprintf("git ls-remote --exit-code --tags https://github.com/ansible-lockdown/%s.git refs/tags/%s", repo, ver)
               print "Validating " role " version " ver
               if (system(cmd) != 0) {

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -7,5 +7,5 @@ roles:
     src: git+https://github.com/ansible-lockdown/UBUNTU22-STIG.git
     version: "1.0.0"
   - name: windows2022-stig
-    src: git+https://github.com/ansible-lockdown/WINDOWS2022-STIG.git
-    version: v1.4.0
+    src: git+https://github.com/ansible-lockdown/Windows-2022-STIG.git
+    version: "1.0.0"


### PR DESCRIPTION
## Summary
- Fixes the remaining CI validation error for windows2022-stig role
- The repository name was incorrect and the version didn't exist

## Changes
- **Repository URL**: Fixed from `WINDOWS2022-STIG` to `Windows-2022-STIG` 
- **Version**: Updated from `v1.4.0` to `1.0.0` (the only available release)
- **CI Enhancement**: Added explicit repository name mapping in validation step

## Validation
Verified the correct repository exists at:
https://github.com/ansible-lockdown/Windows-2022-STIG

Available releases: `1.0.0`

## Test plan
- [x] Verify repository exists and version 1.0.0 is available
- [x] Test that CI validation step passes for all three roles
- [x] Confirm ansible-galaxy can install the corrected role

This completes the fix for all STIG role validation issues in CI.

🤖 Generated with [Claude Code](https://claude.ai/code)