### PR TITLE
Improve Windows bootstrap and add CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,13 @@ jobs:
         with:
           name: reports
           path: reports/
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Windows bootstrap in dry-run mode
+        shell: pwsh
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          ./bootstrap.ps1 -DryRun

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ curl -fsSL https://raw.githubusercontent.com/NotINeverMe/stig-auto/main/bootstra
 iex (irm https://raw.githubusercontent.com/NotINeverMe/stig-auto/main/bootstrap.ps1)
 ```
 
+The Windows bootstrap script installs Python and uses `pip` to fetch Ansible,
+avoiding issues with the older Chocolatey package.
+
 After cloning the repository or running the bootstrap script, install the Ansible roles:
 
 ```bash

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -49,7 +49,10 @@ if (!(Get-Command choco -ErrorAction SilentlyContinue)) {
 }
 
 # Install required packages
-Run 'choco install git ansible openscap -y'
+Run 'choco install git python openscap-scanner -y'
+Run 'refreshenv'
+Run 'python -m pip install --upgrade pip'
+Run 'python -m pip install ansible'
 
 # Clone repo to C:\stig-pipe if not present
 if (!(Test-Path "C:\stig-pipe")) {


### PR DESCRIPTION
## Summary
- install Python and use pip for Ansible in `bootstrap.ps1`
- run `refreshenv` so newly installed tools are in PATH
- note Windows Python/Ansible setup in README
- run Windows bootstrap script in GitHub Actions

## Testing
- `bash bootstrap.sh --dry-run`
- *(fails: shellcheck, ansible install, etc. because network access is not available)*

------
https://chatgpt.com/codex/tasks/task_e_683dd718285c832ebf54e1df8b503ef3