### PR TITLE
Pin Python version in Windows bootstrap

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -58,7 +58,8 @@ if (!(Get-Command choco -ErrorAction SilentlyContinue)) {
 }
 
 # Install required packages
-Run 'choco install git python openscap-scanner -y'
+Run 'choco install git openscap-scanner -y'
+Run 'choco install python --version 3.11.7 -y'
 Run 'refreshenv'
 Run 'python -m pip install --upgrade pip'
 Run 'python -m pip install ansible'


### PR DESCRIPTION
## Summary
- ensure Chocolatey installs Python 3.11.7

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_683e1004f794832ebbfa015cefbb6258