### PR TITLE
Improve SCAP asset matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This pulls the STIG roles from the Git repositories specified in `ansible/requir
 Clone the repo, install roles, fetch SCAP content, then run:
 
 ```bash
-./scripts/get_scap_content.sh [--os rhel-8]
+./scripts/get_scap_content.sh [--os rhel8]
 ./scripts/scan.sh --baseline
 ansible-playbook ansible/remediate.yml -t CAT_I,CAT_II
 ./scripts/verify.sh
@@ -87,7 +87,7 @@ offline target.
 ansible-galaxy install -r ansible/requirements.yml --roles-path roles/
 
 # Download SCAP content for the desired OS
-./scripts/get_scap_content.sh --os rhel-8
+./scripts/get_scap_content.sh --os rhel8
 ```
 
 Transfer the `roles/` and `scap_content/` directories to the offline system

--- a/scripts/get_scap_content.ps1
+++ b/scripts/get_scap_content.ps1
@@ -38,8 +38,19 @@ try {
     # Fallback to SCAP Security Guide GitHub releases
     Write-Host "Falling back to SCAP Security Guide GitHub releases..."
     $GitHubApi = "https://api.github.com/repos/ComplianceAsCode/content/releases/latest"
-    $Release = Invoke-RestMethod -Uri $GitHubApi
-    $Asset = $Release.assets | Where-Object { $_.name -match $OSID } | Select-Object -First 1
+$Release = Invoke-RestMethod -Uri $GitHubApi
+
+switch ($OSID.ToLower()) {
+    'rhel8' {
+        $assetPattern = 'rhel8'
+    }
+    'ubuntu22' { $assetPattern = 'ubuntu-22\.04|ubuntu2204' }
+    'ubuntu2204' { $assetPattern = 'ubuntu-22\.04|ubuntu2204' }
+    'windows2022' { $assetPattern = 'windows-server-2022|windows2022' }
+    Default { $assetPattern = [Regex]::Escape($OSID) }
+}
+
+$Asset = $Release.assets | Where-Object { $_.name -match $assetPattern } | Select-Object -First 1
     $DownloadUrl = $Asset.browser_download_url
     
     if ($DownloadUrl) {

--- a/scripts/get_scap_content.sh
+++ b/scripts/get_scap_content.sh
@@ -42,6 +42,22 @@ fi
 # Create scap_content directory
 mkdir -p scap_content
 
+# Map OS IDs to release asset patterns
+case "${OS_ID}" in
+    rhel8)
+        ASSET_PATTERN="rhel8"
+        ;;
+    ubuntu22|ubuntu2204)
+        ASSET_PATTERN="ubuntu-22\\.04|ubuntu2204"
+        ;;
+    windows2022)
+        ASSET_PATTERN="windows-server-2022|windows2022"
+        ;;
+    *)
+        ASSET_PATTERN="${OS_ID}"
+        ;;
+esac
+
 # Generate filename with current date
 CURRENT_DATE=$(date +"%Y-%m")
 FILENAME="scap_content/${OS_ID}-${CURRENT_DATE}.xml"
@@ -59,11 +75,11 @@ fi
 # Fallback to SCAP Security Guide GitHub releases
 echo "Falling back to SCAP Security Guide GitHub releases..."
 GITHUB_API="https://api.github.com/repos/ComplianceAsCode/content/releases/latest"
-# Find asset matching the OS ID
+# Find asset matching the OS pattern
 DOWNLOAD_URL=$(curl -s "$GITHUB_API" \
     | grep -o '"browser_download_url": "[^"]*' \
     | cut -d'"' -f4 \
-    | grep -i "$OS_ID" \
+    | grep -Ei "$ASSET_PATTERN" \
     | head -n 1)
 
 if [[ -n "$DOWNLOAD_URL" ]]; then


### PR DESCRIPTION
## Summary
- enhance Linux and Windows scripts to match OS variations like `windows-server-2022`
- add lookup regex for RHEL 8, Ubuntu 22.04 and Windows Server 2022
- fix docs to show correct `rhel8` OS override

## Testing
- `bash -n scripts/get_scap_content.sh`
- `./scripts/get_scap_content.sh --os rhel8` *(fails: Could not resolve host)*
- `./scripts/get_scap_content.sh --os windows2022` *(fails: Could not resolve host)*

------
https://chatgpt.com/codex/tasks/task_e_683e1006fbe8832e973b5243918639eb