### PR TITLE
Update Windows Python version note

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ curl -fsSL https://raw.githubusercontent.com/NotINeverMe/stig-auto/main/bootstra
 iex (irm https://raw.githubusercontent.com/NotINeverMe/stig-auto/main/bootstrap.ps1)
 ```
 
-The Windows bootstrap script installs Python and uses `pip` to fetch Ansible,
-avoiding issues with the older Chocolatey package.
+The Windows bootstrap script installs **Python 3.11** and uses `pip` to fetch
+Ansible, avoiding issues with the older Chocolatey package. The pipeline
+requires Python 3.11; using Python 3.13 may result in an `OSError` when running
+Ansible.
 
 After cloning the repository or running the bootstrap script, install the Ansible roles:
 


### PR DESCRIPTION
## Summary
- clarify Windows bootstrap Python requirement
- warn about Python 3.13 errors when running Ansible

## Testing
- `sudo bash bootstrap.sh --dry-run`
- `./scripts/get_scap_content.sh --os rhel-8` *(fails: Falling back to SCAP Security Guide GitHub releases)*
- `./scripts/scan.sh --baseline` *(fails: No SCAP content found)*
- `ansible-playbook ansible/remediate.yml --check` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_683e15f8257c832eb24980784a67a453