### PR TITLE
Fix choco env refresh

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -79,7 +79,7 @@ Run 'choco install git -y'
 # Note: OpenSCAP Chocolatey package currently has issues, will install manually if needed
 Run 'choco install python -y --allow-downgrade'
 
-Run 'refreshenv'
+Run 'Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1; Update-SessionEnvironment'
 
 # Find Python installation dynamically, preferring Ansible-compatible versions
 $PythonCmd = $null


### PR DESCRIPTION
## Summary
- refresh the Chocolatey environment more reliably in `bootstrap.ps1`

## Testing
- `shellcheck $(git ls-files '*.sh')` *(fails: command not found)*
- `ansible-playbook --version` *(fails: command not found)*
- `sudo bash bootstrap.sh --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_6841afc5ef8c832ea876463f97d4da89