### PR TITLE
Add Windows 2019 profile detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,9 @@ which content to download.
 
 - RHEL 8
 - Ubuntu 22.04
-- Windows Server 2022
-- Windows Server 2019 (PowerSTIG + NIST hardening)
+- Windows Server 2022 (`windows2022` profile)
+- Windows Server 2019 (`windows2019` profile, PowerSTIG + NIST hardening)
+- Windows Server 2016 (`windows2016` profile)
 
 ## Windows NIST 800-171 Hardening
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -34,8 +34,13 @@ function Run {
 function Get-StigProfile {
     try {
         $os = Get-CimInstance Win32_OperatingSystem
-        if ($os.Caption -match 'Windows Server 2022') {
+        $caption = $os.Caption
+        if ($caption -match 'Windows Server 2022') {
             return 'windows2022'
+        } elseif ($caption -match 'Windows Server 2019') {
+            return 'windows2019'
+        } elseif ($caption -match 'Windows Server 2016') {
+            return 'windows2016'
         }
     } catch {
         # Default to windows2022 if detection fails


### PR DESCRIPTION
## Summary
- detect Windows Server 2019 and 2016 in Get-StigProfile
- document new STIG profiles in README

## Testing
- `ansible-playbook ansible/remediate.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841afbfeddc832ea6a28a1512a29fb0