### PR TITLE
Set console to UTF-8 for Windows bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ curl -fsSL https://raw.githubusercontent.com/NotINeverMe/stig-auto/main/bootstra
 
 ### Native Windows (PowerShell as Administrator)
 
+Windows PowerShell must use UTF-8 for Python and Ansible. `bootstrap.ps1`
+automatically runs `chcp 65001` to set the console code page before executing
+any commands.
+
 ```powershell
 # Basic STIG remediation
 iex "& { $(irm https://raw.githubusercontent.com/NotINeverMe/stig-auto/main/bootstrap.ps1) }"

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -19,6 +19,7 @@ $EndReport = Join-Path $LogDir "end_report.txt"
 $RepoDir = "C:\stig-pipe"
 New-Item -Path $LogDir -ItemType Directory -Force | Out-Null
 Start-Transcript -Path $LogFile -Append | Out-Null
+Run 'chcp 65001'
 
 function Run {
     param(


### PR DESCRIPTION
## Summary
- run `chcp 65001` at the start of `bootstrap.ps1`
- mention UTF‑8 console requirement in the README

## Testing
- `pwsh -Command "Write-Host test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e30e25d0832e971f83f520bbdeb1