### PR TITLE
Trim audit subcategory names

### DIFF
--- a/scripts/windows-hardening/AuditLogging.psm1
+++ b/scripts/windows-hardening/AuditLogging.psm1
@@ -110,6 +110,7 @@ function Enable-AuditLogging {
                 }
                 
                 foreach ($subcategory in $matches) {
+                    $subcategory = $subcategory.Trim()
                     Write-HardeningLog "Configuring audit policy for: $subcategory" -Level Info
                     
                     # Use the exact subcategory name


### PR DESCRIPTION
## Summary
- trim whitespace from each audit subcategory before configuring the policy

## Testing
- `pwsh --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e3101088832eb6a77fd60432092f